### PR TITLE
Fix multiple downloads not working on Arc/Chrome

### DIFF
--- a/browser-extension/client.js
+++ b/browser-extension/client.js
@@ -874,6 +874,7 @@ async function download_pins(urls) {
             // Trigger the download
             document.body.appendChild(link); // Required for Firefox
             link.click();
+            await new Promise(resolve => setTimeout(resolve, 200));
 
             // Clean up the link
             document.body.removeChild(link);


### PR DESCRIPTION
Currently, if you click to download > 10 pins, only the first 10 download and the rest get dropped. I added a small 200ms delay, as suggested here:
https://stackoverflow.com/questions/53560991/automatic-file-downloads-limited-to-10-files-on-chrome-browser

Now it's working perfectly on my Arc/Chrome browser.